### PR TITLE
Make customizing the page numbers possible

### DIFF
--- a/bookfolder/gui/gui.py
+++ b/bookfolder/gui/gui.py
@@ -46,6 +46,7 @@ class GUI():
             image_input.path,
             pdf_output.path,
             measurement_interval_input.measurement_interval,
+            start_page=page_number_input.first_page_number
             )
 
         self._add_components_vertically(

--- a/bookfolder/gui/widgets.py
+++ b/bookfolder/gui/widgets.py
@@ -135,13 +135,15 @@ class GeneratePatternFrame(WidgetFrame):
     y_padding = ("10p", "3p")
 
     def __init__(self, parent_window, input_path, output_path,
-                 measurement_interval):
+                 measurement_interval, start_page):
+        # pylint: disable=too-many-arguments
         self._frame = ttk.Frame(parent_window)
         self._frame.grid(column=0, row=0, sticky=self.frame_sticky)
 
         self.input_path = input_path
         self.output_path = output_path
         self.measurement_interval = measurement_interval
+        self.start_page = start_page
 
     @property
     def frame(self):
@@ -160,7 +162,8 @@ class GeneratePatternFrame(WidgetFrame):
         Generate the PDF pattern and confirm creation to the user.
         """
         pattern_creator = PatternCreator(self.input_path.get(),
-                                         self.measurement_interval.get())
+                                         self.measurement_interval.get(),
+                                         self.start_page.get())
         pattern_creator.save_pdf(self.output_path.get())
 
         messagebox.showinfo(

--- a/bookfolder/pattern_creator.py
+++ b/bookfolder/pattern_creator.py
@@ -23,7 +23,7 @@ class PatternCreator():
     measurement tool used in the folding process.
     """
 
-    def __init__(self, input_path, measurement_interval=0.25):
+    def __init__(self, input_path, measurement_interval=0.25, start_page=1):
         """
         Initiate the PatternCreator.
 
@@ -33,6 +33,7 @@ class PatternCreator():
         """
         self.input_path = input_path
         self.measurement_interval = measurement_interval
+        self.start_page = start_page
         self._sheets = []
 
     def sheets(self):
@@ -62,7 +63,7 @@ class PatternCreator():
                 Sheet(
                     [inversion.index for inversion in inversions],
                     self.measurement_interval,
-                    page_number=(column_index * 2 + 1)
+                    page_number=(column_index * 2 + self.start_page)
                     )
                 )
 

--- a/bookfolder/scripts/cli.py
+++ b/bookfolder/scripts/cli.py
@@ -12,9 +12,14 @@ from bookfolder.pattern_creator import PatternCreator
 @click.argument("image", type=click.Path(exists=True))
 @click.option("--measurement-interval",
               help="Height of one pixel in the IMAGE in millimeters",
-              default=0.25)
+              default=0.25,
+              type=click.FLOAT)
+@click.option("--start-page",
+              help="The page number of the first sheet in the pattern",
+              default=1,
+              type=click.INT)
 @click.pass_context
-def cli(ctx, image, measurement_interval):
+def cli(ctx, image, measurement_interval, start_page):
     """
     Generate a bookfolding pattern from IMAGE
 
@@ -25,7 +30,7 @@ def cli(ctx, image, measurement_interval):
     """
     ctx.ensure_object(dict)
 
-    pattern_creator = PatternCreator(image, measurement_interval)
+    pattern_creator = PatternCreator(image, measurement_interval, start_page)
     sheets = pattern_creator.sheets()
     ctx.obj["sheets"] = sheets
     ctx.obj["pattern_creator"] = pattern_creator

--- a/tests/pattern_creator_test.py
+++ b/tests/pattern_creator_test.py
@@ -55,3 +55,22 @@ def test_extracted_color_sheets_have_correct_folds_locations():
 def test_extracing_empty_column():
     creator = PatternCreator("tests/data/empty_column_pattern.png")
     assert creator.sheets()[1].folds == []
+
+
+def test_default_start_page():
+    creator = PatternCreator("tests/data/simple_pattern.png")
+    assert creator.sheets()[0].page_number == 1
+
+
+def test_setting_negative_start_page():
+    creator = PatternCreator("tests/data/simple_pattern.png", start_page=-1)
+    assert creator.sheets()[0].page_number == -1
+    assert creator.sheets()[1].page_number == 1
+    assert creator.sheets()[2].page_number == 3
+
+
+def test_setting_positive_start_page():
+    creator = PatternCreator("tests/data/simple_pattern.png", start_page=200)
+    assert creator.sheets()[0].page_number == 200
+    assert creator.sheets()[1].page_number == 202
+    assert creator.sheets()[2].page_number == 204


### PR DESCRIPTION
Add `--start-page` flag to the command line interface and make the box in the graphical UI work. Now unnumbered pages at the start of the book can be taken into account as "negative page numbers" in the pattern or a pattern that is narrower than the book can be started in the middle of the book.